### PR TITLE
Reworks the D20 of fate's critical win roll

### DIFF
--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -292,8 +292,8 @@
 			S.burnmod *= 0.5
 			S.coldmod *= 0.5
 		if(20)
-			//Free wizard!
-			user.mind.make_Wizard()
+			//Gives the roller a healing staff!
+			new /obj/item/gun/magic/staff/healing(drop_location())
 
 
 /datum/outfit/butler


### PR DESCRIPTION
## About The Pull Request
Swaps out the wizard spawn for a healing staff on the D20 of fate
## Why It's Good For The Game
Removes the ability to get an antag roll that doesnt fit the server. prevents bullshit from happening, like the RID 5418 incident.
![image](https://user-images.githubusercontent.com/61367602/126417012-ef77f751-8684-40bf-9af1-53ac3a7c9a9e.png)
![image](https://user-images.githubusercontent.com/61367602/126417021-7ede0f40-a41f-4e77-9289-f418cb23cc03.png)
